### PR TITLE
historic cache control

### DIFF
--- a/public/parking/index.php
+++ b/public/parking/index.php
@@ -37,5 +37,9 @@ if (!isset($_GET['page'])) {
     header('Location: ' . $_ENV["BASE_URL"] . '?page=' . $filename);
 } else {
     $graphs = $fs->get_graphs_from_file_with_links($filename);
-    \otn\linkeddatex2\View::view($_SERVER['HTTP_ACCEPT'], $graphs);
+    $historic = true;
+    if ($filename === $fs->get_last_page()) {
+        $historic = false;
+    }
+    \otn\linkeddatex2\View::view($_SERVER['HTTP_ACCEPT'], $graphs, $historic);
 }

--- a/src/otn/linkeddatex2/View.php
+++ b/src/otn/linkeddatex2/View.php
@@ -11,7 +11,7 @@ use pietercolpaert\hardf\TriGWriter;
 
 Class View
 {
-    private static function headers($acceptHeader) {
+    private static function headers($acceptHeader, $historic) {
         // Content negotiation using vendor/willdurand/negotiation
         $negotiator = new \Negotiation\Negotiator();
         $priorities = array('text/turtle','application/rdf+xml');
@@ -20,7 +20,11 @@ Class View
         header("Content-type: $value");
 
         //Max age is 1/2 minute for caches
-        header("Cache-Control: max-age=30");
+        if ($historic) {
+            header("Cache-Control: max-age=31536000");
+        } else {
+            header("Cache-Control: max-age=30");
+        }
 
         //Allow Cross Origin Resource Sharing
         header("Access-Control-Allow-Origin: *");
@@ -30,8 +34,8 @@ Class View
         return $value;
     }
 
-    public static function view($acceptHeader, $graph){
-        $value = self::headers($acceptHeader);
+    public static function view($acceptHeader, $graph, $historic){
+        $value = self::headers($acceptHeader, $historic);
         $writer = new TriGWriter(["format" => $value]);
         $metadata = Metadata::get();
         foreach ($metadata as $quad) {

--- a/test.php
+++ b/test.php
@@ -21,5 +21,10 @@ $base_url = $_ENV["BASE_URL"] . "?time=";
 // Slowly changing info (name, description, etc) is saved once and added upon request
 //GhentToRDF::map($urls["dynamic_data"], $graph);
 $fs = new \otn\linkeddatex2\gather\ParkingHistoryFilesystem("public/parking/out", "resources");
-$graph = $fs->get_graphs_from_file_with_links("2017-03-28T12:35:00.turtle");
-\otn\linkeddatex2\View::view($_SERVER['HTTP_ACCEPT'], $graph);
+$graph = $fs->get_graphs_from_file_with_links("2017-03-28T12:35:00");
+$historic = true;
+if ("2017-03-28T12:35:00" === $fs->get_last_page()) {
+    $historic = false;
+}
+echo $fs->get_last_page();
+\otn\linkeddatex2\View::view('text/turtle', $graph, true);


### PR DESCRIPTION
Sets cache control headers for current file to 30 seconds (since this file can still be updated), and for older files to 1 year (since these files are not expected to change).